### PR TITLE
Use unary_union instead of cascaded_union

### DIFF
--- a/polygon_geohasher/polygon_geohasher.py
+++ b/polygon_geohasher/polygon_geohasher.py
@@ -2,7 +2,7 @@ import geohash
 import queue
 
 from shapely import geometry
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 
 def geohash_to_polygon(geo):
@@ -77,4 +77,4 @@ def geohashes_to_polygon(geohashes):
     :param geohashes: array-like. List of geohashes to form resulting polygon.
     :return: shapely geometry. Resulting Polygon after combining geohashes.
     """
-    return cascaded_union([geohash_to_polygon(g) for g in geohashes])
+    return unary_union([geohash_to_polygon(g) for g in geohashes])

--- a/polygon_geohasher/version.py
+++ b/polygon_geohasher/version.py
@@ -5,5 +5,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from polygon_geohasher.polygon_geohasher import (
     polygon_to_geohashes,
@@ -6,6 +7,7 @@ from polygon_geohasher.polygon_geohasher import (
     geohashes_to_polygon,
 )
 from shapely import geometry
+from shapely.errors import ShapelyDeprecationWarning
 
 
 class TestSimpleMethods(unittest.TestCase):
@@ -37,6 +39,26 @@ class TestSimpleMethods(unittest.TestCase):
         polygon = geohashes_to_polygon(polygon_to_geohashes(test_polygon, 7, False))
 
         self.assertTrue(polygon.area >= test_polygon.area)
+
+
+class TestWarnings(unittest.TestCase):
+    def test_no_shapely_deprecation_warnings(self):
+        test_geohashes = ["x1", "x2"]
+
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            _ = geohashes_to_polygon(test_geohashes)
+        
+        captured_shapely_warnings = [w for w in captured_warnings if w.category == ShapelyDeprecationWarning]
+        failure_message = "".join([
+            warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
+            for w in captured_shapely_warnings
+        ])
+        
+        self.assertEqual(
+            len(captured_shapely_warnings),
+            0,
+            msg=failure_message
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This raises a `DeprecationWarning` in Shapely 1 and an error in Shapely 2.